### PR TITLE
fixes for Symfony autoload issue and undefined variable issue

### DIFF
--- a/Tests/DetectorTest.php
+++ b/Tests/DetectorTest.php
@@ -63,6 +63,9 @@ if (!defined('TEST_FILES_PATH')) {
  */
 class PHPDCD_DetectorTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var PHPDCD_Detector
+     */
     protected $detector;
 
     protected function setUp()


### PR DESCRIPTION
9ab7becb380e58a929089e3898e8ef7f52d2006b When trying out the latest version of phpdcd I had Symfony autoloader issues:
PHPDCD/Autoload.php uses explicit includes of symfony classes, without the symfony autoloader loaded at that point, which caused include dependency hell. Just loading Symfony/Component/Finder/autoloader.php fixed the issue for me

34757babcc1d58edf8fd0061e858c2261aa7e859  other issue: I got "Undefined variable: commonPath" notices
