### PR TITLE
Load Symfony Finder's autoloader.php instead of brittle hardcoded requires

### DIFF
--- a/PHPDCD/Autoload.php
+++ b/PHPDCD/Autoload.php
@@ -41,14 +41,7 @@
  * @since     File available since Release 1.0.0
  */
 
-require_once 'Symfony/Component/Finder/Finder.php';
-require_once 'Symfony/Component/Finder/Glob.php';
-require_once 'Symfony/Component/Finder/Iterator/FileTypeFilterIterator.php';
-require_once 'Symfony/Component/Finder/Iterator/MultiplePcreFilterIterator.php';
-require_once 'Symfony/Component/Finder/Iterator/FilenameFilterIterator.php';
-require_once 'Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php';
-require_once 'Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php';
-require_once 'Symfony/Component/Finder/SplFileInfo.php';
+require_once 'Symfony/Component/Finder/autoloader.php';
 require_once 'PHP/Token/Stream/Autoload.php';
 require_once 'PHP/Timer/Autoload.php';
 require_once 'ezc/Base/base.php';

--- a/PHPDCD/Autoload.php.in
+++ b/PHPDCD/Autoload.php.in
@@ -41,14 +41,7 @@
  * @since     File available since Release 1.0.0
  */
 
-require_once 'Symfony/Component/Finder/Finder.php';
-require_once 'Symfony/Component/Finder/Glob.php';
-require_once 'Symfony/Component/Finder/Iterator/FileTypeFilterIterator.php';
-require_once 'Symfony/Component/Finder/Iterator/MultiplePcreFilterIterator.php';
-require_once 'Symfony/Component/Finder/Iterator/FilenameFilterIterator.php';
-require_once 'Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php';
-require_once 'Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php';
-require_once 'Symfony/Component/Finder/SplFileInfo.php';
+require_once 'Symfony/Component/Finder/autoloader.php';
 require_once 'PHP/Token/Stream/Autoload.php';
 require_once 'PHP/Timer/Autoload.php';
 require_once 'ezc/Base/base.php';


### PR DESCRIPTION
When trying out the latest version of phpdcd I had Symfony autoloader issues:
PHPDCD/Autoload.php uses explicit includes of symfony classes, without the symfony autoloader loaded at that point, which caused include dependency hell. Just loading Symfony/Component/Finder/autoloader.php fixed the issue for me
