### PR TITLE
(Re)introduce progress bar

### DIFF
--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -129,12 +129,18 @@ class Command extends AbstractCommand
 
         $quiet = $output->getVerbosity() == OutputInterface::VERBOSITY_QUIET;
 
+        $progressBar = $this->getHelperSet()->get('progress');
+        $progressBar->start($output, count($files));
+
         $detector = new Detector;
 
         $result = $detector->detectDeadCode(
             $files,
-            $input->getOption('recursive')
+            $input->getOption('recursive'),
+            function ($file) use ($progressBar) { $progressBar->advance(); }
         );
+
+        $progressBar->finish();
 
         if (!$quiet) {
             $printer = new Text;

--- a/src/Detector.php
+++ b/src/Detector.php
@@ -56,17 +56,21 @@ namespace SebastianBergmann\PHPDCD;
 class Detector
 {
     /**
-     * @param  array   $files
-     * @param  boolean $recursive
+     * @param  array    $files
+     * @param  boolean  $recursive
+     * @param  callable $advanceCallback closure to call each time a file is analysed
      * @return array
      */
-    public function detectDeadCode(array $files, $recursive = false)
+    public function detectDeadCode(array $files, $recursive = false, \Closure $advanceCallback=null)
     {
 
         // Analyse files and collect declared and called functions
         $analyser = new Analyser();
         foreach ($files as $file) {
             $analyser->analyseFile($file);
+            if ($advanceCallback) {
+                $advanceCallback($file);
+            }
         }
 
         // Get info on declared and called functions.


### PR DESCRIPTION
A progress bar was originally implemented with ezcConsoleProgressbar,
but this was removed by commit 31d5d775f8bedb6a189ed8289047c3d87b04e7e4

This commit re-introduces a progress bar using Symfony\Component\Console\Helper\ProgressHelper
