### PR TITLE
Ignore abstract methods

### DIFF
--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -232,6 +232,14 @@ class Analyser
                     continue;
                 }
 
+                // Ignore abstract methods.
+                for ($j=1; $j<=4; $j++) {
+                    if (isset($tokens[$i-$j]) &&
+                        $tokens[$i-$j] instanceof \PHP_Token_ABSTRACT) {
+                        continue 2;
+                    }
+                }
+
                 $function = $tokens[$i]->getName();
 
                 if ($function == 'anonymous function') {

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -277,5 +277,18 @@ class AnalyserTest extends PHPUnit_Framework_TestCase
     }
 
 
+    /**
+     * @covers SebastianBergmann\PHPDCD\Analyser::getFunctionDeclarations
+     */
+    public function testIgnoreAbstractMethods()
+    {
+        $file = TEST_FILES_PATH . 'abstract_methods.php';
+        $this->analyser->analyseFile($file);
+        $this->assertEquals(
+            array('Painting::getShape'),
+            array_keys($this->analyser->getFunctionDeclarations())
+        );
+    }
+
 
 }

--- a/tests/DetectorTest.php
+++ b/tests/DetectorTest.php
@@ -504,4 +504,15 @@ class DetectorTest extends PHPUnit_Framework_TestCase
     }
 
 
+    /**
+     * @covers SebastianBergmann\PHPDCD\Detector::detectDeadCode
+     */
+    public function testIgnoreAbstractMethods()
+    {
+        $file = TEST_FILES_PATH . 'abstract_methods.php';
+        $result = $this->detector->detectDeadCode(array($file), FALSE);
+        $this->assertEquals(array('Painting::getShape'), array_keys($result));
+
+    }
+
 }

--- a/tests/_files/abstract_methods.php
+++ b/tests/_files/abstract_methods.php
@@ -1,0 +1,15 @@
+<?php
+
+abstract class Painting
+{
+
+    abstract public function getColors();
+
+    abstract public function getPrice();
+
+    public function getShape()
+    {
+        return 'rectangle';
+    }
+
+}


### PR DESCRIPTION
Abstract methods are not interesting in dead code
analysis as they can not be called by design.
